### PR TITLE
record response body for irisyaag

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ func main() {
 3. Initialize yaag `yaag.Init(&yaag.Config(On: true, DocTile: "Iris", DocPath: "apidoc.html"))`
 4. Register yaag middleware like `app.Use(irisyaag.New())`
 
+> `irisyaag` records the response body and provides all the necessary information to the apidoc.
+
 ### Sample Code
 
 ```go
@@ -171,7 +173,7 @@ func main() {
   // Write tests that calls those handlers, save the generated "apidoc.html".
   // Turn off the yaag middleware when in production.
   //
-  // Usage:
+  // Example usage:
   // Visit all paths and open the generated "apidoc.html" file to see the API's automated docs.
   app.Run(iris.Addr(":8080"))
 }

--- a/examples/iris/main.go
+++ b/examples/iris/main.go
@@ -47,7 +47,7 @@ func main() {
 	// Write tests that calls those handlers, save the generated "apidoc.html".
 	// Turn off the yaag middleware when in production.
 	//
-	// Usage:
+	// Example usage:
 	// Visit all paths and open the generated "apidoc.html" file to see the API's automated docs.
 	app.Run(iris.Addr(":8080"))
 }


### PR DESCRIPTION
the rest of the frameworks can't do that, except one, by-default; iris can so why not