### PR TITLE
Setting Content-Type when status code is 404

### DIFF
--- a/middleware/yaagmiddleware.go
+++ b/middleware/yaagmiddleware.go
@@ -196,24 +196,25 @@ func ReadBody(req *http.Request) *string {
 	return &body
 }
 
-func After(apiCall *models.ApiCall, writer *httptest.ResponseRecorder, w http.ResponseWriter, r *http.Request) {
+func After(apiCall *models.ApiCall, record *httptest.ResponseRecorder, output http.ResponseWriter, r *http.Request) {
 	if strings.Contains(r.RequestURI, ".ico") {
-		fmt.Fprintf(w, writer.Body.String())
+		fmt.Fprintf(output, record.Body.String())
 		return
 	}
-	if writer.Code != 404 {
-		apiCall.MethodType = r.Method
-		apiCall.CurrentPath = strings.Split(r.RequestURI, "?")[0]
-		apiCall.ResponseBody = writer.Body.String()
-		apiCall.ResponseCode = writer.Code
-		apiCall.ResponseHeader = ReadHeadersFromResponse(writer)
+
+	apiCall.MethodType = r.Method
+	apiCall.CurrentPath = strings.Split(r.RequestURI, "?")[0]
+	apiCall.ResponseBody = record.Body.String()
+	apiCall.ResponseCode = record.Code
+	apiCall.ResponseHeader = ReadHeadersFromResponse(record)
+	if record.Code != 404 {
 		go yaag.GenerateHtml(apiCall)
 	}
 	for key, value := range apiCall.ResponseHeader {
-		w.Header().Add(key, value)
+		output.Header().Add(key, value)
 	}
-	w.WriteHeader(writer.Code)
-	w.Write(writer.Body.Bytes())
+	output.WriteHeader(record.Code)
+	output.Write(record.Body.Bytes())
 }
 
 // One of the copies, say from b to r2, could be avoided by using a more

--- a/middleware/yaagmiddleware_test.go
+++ b/middleware/yaagmiddleware_test.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/betacraft/yaag/yaag/models"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAfterSetContentType(t *testing.T) {
+
+	type test struct {
+		code             int
+		contentTypeKey   string
+		contentTypeValue string
+	}
+
+	tests := []test{
+		{http.StatusOK, "Content-Type", "application/json"},
+		{http.StatusInternalServerError, "Content-Type", "application/json"},
+		{http.StatusBadRequest, "Content-Type", "application/json"},
+		{http.StatusNotFound, "Content-Type", "application/json"},
+	}
+
+	testResponseBody := map[string]string{"test": "yo"}
+
+	body := new(bytes.Buffer)
+	if err := json.NewEncoder(body).Encode(testResponseBody); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		request := httptest.NewRequest(http.MethodGet, "/test", nil)
+		record := httptest.NewRecorder()
+		record.Code = test.code
+		record.Header().Set(test.contentTypeKey, test.contentTypeValue)
+		record.Body = body
+
+		outputRecorder := httptest.NewRecorder()
+		After(&models.ApiCall{}, record, outputRecorder, request)
+
+		if outputRecorder.Code != test.code {
+			t.Errorf("expected code to be %d, was %s", test.code, outputRecorder.Code)
+		}
+
+		contentType := outputRecorder.Header().Get(test.contentTypeKey)
+		if contentType != test.contentTypeValue {
+			t.Errorf("expected header %s to be %s, was %s", test.contentTypeKey, test.contentTypeValue, contentType)
+		}
+
+	}
+
+}


### PR DESCRIPTION
#31 

Hi, this PR solves the problem where `After func` didn't set up response header Content-Type properly.